### PR TITLE
Fix model serving endpoint URL missing /api/2.0 prefix

### DIFF
--- a/nodes/Databricks/resources/modelServing.ts
+++ b/nodes/Databricks/resources/modelServing.ts
@@ -92,7 +92,7 @@ export const modelServingOperations: INodeProperties = {
             routing: {
                 request: {
                     method: 'POST',
-                    url: '/serving-endpoints/{{$parameter.endpointName}}/invocations',
+                    url: '/api/2.0/serving-endpoints/={{$parameter.endpointName}}/invocations',
                     body: {
                         inputs: '={{$parameter.inputs}}',
                     },


### PR DESCRIPTION
### Problem
The "Query Endpoint" operation in model serving was failing because the URL was missing the `/api/2.0` prefix, causing requests to go to the wrong endpoint.

### Changes
- Fixed URL in `modelServing.ts` from `/serving-endpoints/...` to `/api/2.0/serving-endpoints/...`